### PR TITLE
chore(fallow): ignore ESLint plugin deps loaded via oxlint jsPlugins

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,5 +1,10 @@
 {
   "entry": ["src/vitest.setup.ts"],
+  "ignoreDependencies": [
+    "eslint-plugin-testing-library",
+    "eslint-plugin-playwright",
+    "eslint-plugin-sonarjs"
+  ],
   "usedClassMembers": [
     {
       "implements": "IMediaSessionService",


### PR DESCRIPTION
fallow cannot detect oxlint's jsPlugins config, so it flags
testing-library, playwright, and sonarjs plugins as unused.
They are loaded dynamically by oxlint, not imported directly.
